### PR TITLE
Replace some of the private http_* methods with attr_reader

### DIFF
--- a/lib/tankard/api/beer.rb
+++ b/lib/tankard/api/beer.rb
@@ -19,8 +19,8 @@ module Tankard
       # @param options [Hash]
       # @return [Tankard::Api::Beer]
       def initialize(request, options = {})
-        @request = request
-        @options = Hashie::Mash.new(options)
+        @http_client = request
+        @http_request_parameters = Hashie::Mash.new(options)
       end
 
       # @!method find(id_or_array, options={})
@@ -47,7 +47,7 @@ module Tankard
       # @param beer_id [String]
       # @return [self] returns itself
       def id(beer_id)
-        @options.id = beer_id
+        @http_request_parameters.id = beer_id
         self
       end
 
@@ -55,7 +55,7 @@ module Tankard
       #
       # @return [self] returns itself
       def breweries
-        @options.endpoint = 'breweries'
+        @http_request_parameters.endpoint = 'breweries'
         self
       end
 
@@ -63,7 +63,7 @@ module Tankard
       #
       # @return [self] returns itself
       def events
-        @options.endpoint = 'events'
+        @http_request_parameters.endpoint = 'events'
         self
       end
 
@@ -71,7 +71,7 @@ module Tankard
       #
       # @return [self] returns itself
       def ingredients
-        @options.endpoint = 'ingredients'
+        @http_request_parameters.endpoint = 'ingredients'
         self
       end
 
@@ -79,7 +79,7 @@ module Tankard
       #
       # @return [self] returns itself
       def social_accounts
-        @options.endpoint = 'socialaccounts'
+        @http_request_parameters.endpoint = 'socialaccounts'
         self
       end
 
@@ -87,7 +87,7 @@ module Tankard
       #
       # @return [self] returns itself
       def variations
-        @options.endpoint = 'variations'
+        @http_request_parameters.endpoint = 'variations'
         self
       end
 
@@ -97,36 +97,31 @@ module Tankard
       # @return [self] returns itself
       def params(options = {})
         options.each_pair do |key, value|
-          @options[key] = value
+          @http_request_parameters[key] = value
         end
         self
       end
 
     private
 
+      attr_reader :http_client
+      attr_reader :http_request_parameters
+
       def http_request_uri
         endpoint = "#{route}/#{raise_if_no_id_in_options}"
 
-        endpoint += "/#{@options.delete(:endpoint)}" if @options.endpoint?
+        endpoint += "/#{@http_request_parameters.delete(:endpoint)}" if @http_request_parameters.endpoint?
 
         endpoint
       end
 
       def raise_if_no_id_in_options
-        fail Tankard::Error::MissingParameter, 'No Beer ID is set' unless @options.id?
-        @options.delete(:id)
+        fail Tankard::Error::MissingParameter, 'No Beer ID is set' unless @http_request_parameters.id?
+        @http_request_parameters.delete(:id)
       end
 
       def route
         'beer'
-      end
-
-      def http_client
-        @request
-      end
-
-      def http_request_parameters
-        @options
       end
     end
   end

--- a/lib/tankard/api/beers.rb
+++ b/lib/tankard/api/beers.rb
@@ -19,8 +19,8 @@ module Tankard
       # @param options [Hash]
       # @return [Tankard::Api::Beers]
       def initialize(request, options = {})
-        @request = request
-        @options = Hashie::Mash.new(options)
+        @http_client = request
+        @http_request_parameters = Hashie::Mash.new(options)
       end
 
       # @!method each(&block)
@@ -37,7 +37,7 @@ module Tankard
       # @param beer_name [String]
       # @return [self] returns itself
       def name(beer_name)
-        @options.name = beer_name
+        @http_request_parameters.name = beer_name
         self
       end
 
@@ -46,7 +46,7 @@ module Tankard
       # @param number [Integer]
       # @return [self] returns itself
       def page(number)
-        @options.p = number
+        @http_request_parameters.p = number
         self
       end
 
@@ -56,23 +56,18 @@ module Tankard
       # @return [self] returns itself
       def params(options = {})
         options.each_pair do |key, value|
-          @options[key] = value
+          @http_request_parameters[key] = value
         end
         self
       end
 
     private
 
+      attr_reader :http_client
+      attr_reader :http_request_parameters
+
       def http_request_uri
         'beers'
-      end
-
-      def http_client
-        @request
-      end
-
-      def http_request_parameters
-        @options
       end
     end
   end

--- a/lib/tankard/api/search.rb
+++ b/lib/tankard/api/search.rb
@@ -18,8 +18,8 @@ module Tankard
       # @param options [Hash]
       # @return [Tankard::Api::Search]
       def initialize(request, options = {})
-        @request = request
-        @options = Hashie::Mash.new(options)
+        @http_client = request
+        @http_request_parameters = Hashie::Mash.new(options)
       end
 
       # Calls the given block once for each result
@@ -40,7 +40,7 @@ module Tankard
       # @param search_query [String]
       # @return [self] returns itself
       def query(search_query)
-        @options.q = search_query
+        @http_request_parameters.q = search_query
         self
       end
 
@@ -49,7 +49,7 @@ module Tankard
       # @param number [Integer]
       # @return [self] returns itself
       def page(number)
-        @options.p = number
+        @http_request_parameters.p = number
         self
       end
 
@@ -59,7 +59,7 @@ module Tankard
       # @return [self] returns itself
       def params(options = {})
         options.each_pair do |key, value|
-          @options[key] = value
+          @http_request_parameters[key] = value
         end
         self
       end
@@ -69,7 +69,7 @@ module Tankard
       # @param search_type [String]
       # @return [self] returns itself
       def type(search_type)
-        @options.type = search_type
+        @http_request_parameters.type = search_type
         self
       end
 
@@ -79,8 +79,8 @@ module Tankard
       # @param upc_code [Integer]
       # @return [self] returns itself
       def upc(upc_code)
-        @options.code = upc_code
-        @options.endpoint = 'upc'
+        @http_request_parameters.code = upc_code
+        @http_request_parameters.endpoint = 'upc'
         self
       end
 
@@ -91,37 +91,32 @@ module Tankard
       # @param longitude [Float]
       # @return [self] returns itself
       def geo_point(latitude, longitude)
-        @options.lat = latitude
-        @options.lng = longitude
-        @options.endpoint = 'geo/point'
+        @http_request_parameters.lat = latitude
+        @http_request_parameters.lng = longitude
+        @http_request_parameters.endpoint = 'geo/point'
         self
       end
 
     private
 
+      attr_reader :http_client
+      attr_reader :http_request_parameters
+
       def http_request_uri
         endpoint = 'search'
 
-        endpoint += "/#{@options.delete(:endpoint)}" if @options.endpoint?
+        endpoint += "/#{@http_request_parameters.delete(:endpoint)}" if @http_request_parameters.endpoint?
 
         endpoint
       end
 
-      def http_client
-        @request
-      end
-
-      def http_request_parameters
-        @options
-      end
-
       def raise_if_required_options_not_set
-        if @options.endpoint.nil?
-          fail Tankard::Error::MissingParameter, 'No search query set' unless @options.q?
-        elsif @options.endpoint == 'upc'
-          fail Tankard::Error::MissingParameter, 'missing parameter: code' unless @options.code?
-        elsif @options.endpoint == 'geo/point'
-          fail Tankard::Error::MissingParameter, 'missing Parameters: lat, lng' unless @options.lat? && @options.lng?
+        if @http_request_parameters.endpoint.nil?
+          fail Tankard::Error::MissingParameter, 'No search query set' unless @http_request_parameters.q?
+        elsif @http_request_parameters.endpoint == 'upc'
+          fail Tankard::Error::MissingParameter, 'missing parameter: code' unless @http_request_parameters.code?
+        elsif @http_request_parameters.endpoint == 'geo/point'
+          fail Tankard::Error::MissingParameter, 'missing Parameters: lat, lng' unless @http_request_parameters.lat? && @http_request_parameters.lng?
         end
       end
     end

--- a/lib/tankard/api/style.rb
+++ b/lib/tankard/api/style.rb
@@ -21,8 +21,8 @@ module Tankard
       # @param options [Hash]
       # @return [Tankard::Api::Style]
       def initialize(request, options = {})
-        @request = request
-        @options = Hashie::Mash.new(options)
+        @http_client = request
+        @http_request_parameters = Hashie::Mash.new(options)
       end
 
       # @!method find(id_or_array, options={})
@@ -49,15 +49,18 @@ module Tankard
       # @param style_id [String]
       # @return [self] returns itself
       def id(style_id)
-        @options.id = style_id
+        @http_request_parameters.id = style_id
         self
       end
 
     private
 
+      attr_reader :http_client
+      attr_reader :http_request_parameters
+
       def raise_if_no_id_in_options
-        fail Tankard::Error::MissingParameter, 'No style id set' unless @options.id?
-        @options.delete(:id)
+        fail Tankard::Error::MissingParameter, 'No style id set' unless @http_request_parameters.id?
+        @http_request_parameters.delete(:id)
       end
 
       def route
@@ -66,14 +69,6 @@ module Tankard
 
       def http_request_uri
         "#{route}/#{raise_if_no_id_in_options}"
-      end
-
-      def http_client
-        @request
-      end
-
-      def http_request_parameters
-        @options
       end
     end
   end

--- a/lib/tankard/api/styles.rb
+++ b/lib/tankard/api/styles.rb
@@ -27,17 +27,15 @@ module Tankard
       # @param request [Tankard::Request]
       # @return [Tankard::Api::Styles]
       def initialize(request)
-        @request = request
+        @http_client = request
       end
 
     private
 
+      attr_reader :http_client
+
       def http_request_uri
         'styles'
-      end
-
-      def http_client
-        @request
       end
 
       def http_request_parameters

--- a/spec/tankard/api/beer_spec.rb
+++ b/spec/tankard/api/beer_spec.rb
@@ -30,7 +30,7 @@ describe Tankard::Api::Beer do
 
     it 'sets the options[:id] to the beer id passed in' do
       beer.id('port')
-      beer_options = beer.instance_variable_get(:"@options")
+      beer_options = beer.instance_variable_get(:"@http_request_parameters")
       expect(beer_options[:id]).to eql('port')
     end
 
@@ -43,7 +43,7 @@ describe Tankard::Api::Beer do
 
     it 'sets the options[:endpoint] to breweries' do
       beer.breweries
-      beer_options = beer.instance_variable_get(:"@options")
+      beer_options = beer.instance_variable_get(:"@http_request_parameters")
       expect(beer_options[:endpoint]).to eql('breweries')
     end
 
@@ -56,7 +56,7 @@ describe Tankard::Api::Beer do
 
     it 'sets the options[:endpoint] to events' do
       beer.events
-      beer_options = beer.instance_variable_get(:"@options")
+      beer_options = beer.instance_variable_get(:"@http_request_parameters")
       expect(beer_options[:endpoint]).to eql('events')
     end
 
@@ -69,7 +69,7 @@ describe Tankard::Api::Beer do
 
     it 'sets the options[:endpoint] to ingredients' do
       beer.ingredients
-      beer_options = beer.instance_variable_get(:"@options")
+      beer_options = beer.instance_variable_get(:"@http_request_parameters")
       expect(beer_options[:endpoint]).to eql('ingredients')
     end
 
@@ -82,7 +82,7 @@ describe Tankard::Api::Beer do
 
     it 'sets the options[:endpoint] to socialaccounts' do
       beer.social_accounts
-      beer_options = beer.instance_variable_get(:"@options")
+      beer_options = beer.instance_variable_get(:"@http_request_parameters")
       expect(beer_options[:endpoint]).to eql('socialaccounts')
     end
 
@@ -95,7 +95,7 @@ describe Tankard::Api::Beer do
 
     it 'sets the options[:endpoint] to variations' do
       beer.variations
-      beer_options = beer.instance_variable_get(:"@options")
+      beer_options = beer.instance_variable_get(:"@http_request_parameters")
       expect(beer_options[:endpoint]).to eql('variations')
     end
 
@@ -108,7 +108,7 @@ describe Tankard::Api::Beer do
 
     it 'sets parameters' do
       beer.params(withSocialAccounts: 'y', withGuilds: 'n')
-      beer_options = beer.instance_variable_get(:"@options")
+      beer_options = beer.instance_variable_get(:"@http_request_parameters")
       expect(beer_options[:withSocialAccounts]).to eql('y')
       expect(beer_options[:withGuilds]).to eql('n')
     end
@@ -116,7 +116,7 @@ describe Tankard::Api::Beer do
     it 'merges data when called multiple times' do
       beer.params(test: 'n')
       beer.params(test: 'y')
-      beer_options = beer.instance_variable_get(:"@options")
+      beer_options = beer.instance_variable_get(:"@http_request_parameters")
       expect(beer_options[:test]).to eql('y')
     end
 
@@ -139,7 +139,7 @@ describe Tankard::Api::Beer do
       context 'when an ID is set' do
 
         before do
-          beer.instance_variable_get(:"@options")[:id] = 'test'
+          beer.instance_variable_get(:"@http_request_parameters")[:id] = 'test'
         end
 
         it 'returns the id from options' do
@@ -148,7 +148,7 @@ describe Tankard::Api::Beer do
 
         it 'removes the id from options' do
           beer.send(:raise_if_no_id_in_options)
-          expect(beer.instance_variable_get(:"@options")[:id]).to be_nil
+          expect(beer.instance_variable_get(:"@http_request_parameters")[:id]).to be_nil
         end
       end
     end
@@ -177,7 +177,7 @@ describe Tankard::Api::Beer do
       context 'endpoint is set' do
 
         before do
-          beer.instance_variable_get(:"@options")[:endpoint] = 'events'
+          beer.instance_variable_get(:"@http_request_parameters")[:endpoint] = 'events'
         end
 
         it 'returns the route with the id and endpoint' do
@@ -186,7 +186,7 @@ describe Tankard::Api::Beer do
 
         it 'removes the endpoint from options' do
           beer.send(:http_request_uri)
-          expect(beer.instance_variable_get(:"@options")[:endpoint]).to be_nil
+          expect(beer.instance_variable_get(:"@http_request_parameters")[:endpoint]).to be_nil
         end
       end
     end
@@ -201,7 +201,7 @@ describe Tankard::Api::Beer do
     describe '#http_request_parameters' do
 
       it 'returns the options for the request' do
-        expect(beer.send(:http_request_parameters).object_id).to eql(beer.instance_variable_get(:"@options").object_id)
+        expect(beer.send(:http_request_parameters).object_id).to eql(beer.instance_variable_get(:"@http_request_parameters").object_id)
       end
     end
   end

--- a/spec/tankard/api/beers_spec.rb
+++ b/spec/tankard/api/beers_spec.rb
@@ -9,9 +9,9 @@ describe Tankard::Api::Beers do
 
   describe '#name' do
 
-    it 'sets the options[:name] of a beer' do
+    it 'sets the http_request_parameters[:name] of a beer' do
       beers.name('stone')
-      beers_options = beers.instance_variable_get(:"@options")
+      beers_options = beers.instance_variable_get(:"@http_request_parameters")
       expect(beers_options[:name]).to eql('stone')
     end
 
@@ -22,9 +22,9 @@ describe Tankard::Api::Beers do
 
   describe '#page' do
 
-    it 'sets the options[:p] for the page number' do
+    it 'sets the http_request_parameters[:p] for the page number' do
       beers.page(1)
-      beers_options = beers.instance_variable_get(:"@options")
+      beers_options = beers.instance_variable_get(:"@http_request_parameters")
       expect(beers_options[:p]).to eql(1)
     end
 
@@ -37,7 +37,7 @@ describe Tankard::Api::Beers do
 
     it 'sets parameters' do
       beers.params(withSocialAccounts: 'y', withGuilds: 'n')
-      beers_options = beers.instance_variable_get(:"@options")
+      beers_options = beers.instance_variable_get(:"@http_request_parameters")
       expect(beers_options[:withSocialAccounts]).to eql('y')
       expect(beers_options[:withGuilds]).to eql('n')
     end
@@ -45,7 +45,7 @@ describe Tankard::Api::Beers do
     it 'merges params when called multiple times' do
       beers.params(test: 'n')
       beers.params(test: 'y')
-      beers_options = beers.instance_variable_get(:"@options")
+      beers_options = beers.instance_variable_get(:"@http_request_parameters")
       expect(beers_options[:test]).to eql('y')
     end
 
@@ -72,8 +72,8 @@ describe Tankard::Api::Beers do
 
     describe '#http_request_parameters' do
 
-      it 'returns the options for the request' do
-        expect(beers.send(:http_request_parameters).object_id).to eql(beers.instance_variable_get(:"@options").object_id)
+      it 'returns the http_request_parameters for the request' do
+        expect(beers.send(:http_request_parameters).object_id).to eql(beers.instance_variable_get(:"@http_request_parameters").object_id)
       end
     end
   end

--- a/spec/tankard/api/search_spec.rb
+++ b/spec/tankard/api/search_spec.rb
@@ -10,9 +10,9 @@ describe Tankard::Api::Search do
 
   describe '#query' do
 
-    it 'sets options[:q] with the query the user wants to run' do
+    it 'sets http_request_parameters[:q] with the query the user wants to run' do
       search.query('test')
-      search_options = search.instance_variable_get(:"@options")
+      search_options = search.instance_variable_get(:"@http_request_parameters")
       expect(search_options[:q]).to eql('test')
     end
 
@@ -26,7 +26,7 @@ describe Tankard::Api::Search do
 
     it 'sets parameters' do
       search.params(withSocialAccounts: 'y', withGuilds: 'n')
-      search_options = search.instance_variable_get(:"@options")
+      search_options = search.instance_variable_get(:"@http_request_parameters")
       expect(search_options[:withSocialAccounts]).to eql('y')
       expect(search_options[:withGuilds]).to eql('n')
     end
@@ -34,7 +34,7 @@ describe Tankard::Api::Search do
     it 'merges params when called multiple times' do
       search.params(test: 'n')
       search.params(test: 'y')
-      search_options = search.instance_variable_get(:"@options")
+      search_options = search.instance_variable_get(:"@http_request_parameters")
       expect(search_options[:test]).to eql('y')
     end
 
@@ -45,9 +45,9 @@ describe Tankard::Api::Search do
 
   describe '#type' do
 
-    it 'sets options[:type] with the type to search for' do
+    it 'sets http_request_parameters[:type] with the type to search for' do
       search.type('beer')
-      search_options = search.instance_variable_get(:"@options")
+      search_options = search.instance_variable_get(:"@http_request_parameters")
       expect(search_options[:type]).to eql('beer')
     end
 
@@ -58,9 +58,9 @@ describe Tankard::Api::Search do
 
   describe '#page' do
 
-    it 'sets options[:p] with the page number to load' do
+    it 'sets http_request_parameters[:p] with the page number to load' do
       search.page(1)
-      search_options = search.instance_variable_get(:"@options")
+      search_options = search.instance_variable_get(:"@http_request_parameters")
       expect(search_options[:p]).to eql(1)
     end
 
@@ -73,14 +73,14 @@ describe Tankard::Api::Search do
 
     before do
       search.upc('123')
-      @search_options = search.instance_variable_get(:"@options")
+      @search_options = search.instance_variable_get(:"@http_request_parameters")
     end
 
-    it 'sets options[:endpoint] with the search endpoint to use' do
+    it 'sets http_request_parameters[:endpoint] with the search endpoint to use' do
       expect(@search_options[:endpoint]).to eql('upc')
     end
 
-    it 'sets options[:code] with the upc code' do
+    it 'sets http_request_parameters[:code] with the upc code' do
       expect(@search_options[:code]).to eql('123')
     end
 
@@ -93,18 +93,18 @@ describe Tankard::Api::Search do
 
     before do
       search.geo_point(1.23, 4.56)
-      @search_options = search.instance_variable_get(:"@options")
+      @search_options = search.instance_variable_get(:"@http_request_parameters")
     end
 
-    it 'sets options[:endpoint] with the correct search endpoint to use' do
+    it 'sets http_request_parameters[:endpoint] with the correct search endpoint to use' do
       expect(@search_options[:endpoint]).to eql('geo/point')
     end
 
-    it 'sets options[:lat] with the latitude' do
+    it 'sets http_request_parameters[:lat] with the latitude' do
       expect(@search_options[:lat]).to eql(1.23)
     end
 
-    it 'sets options[:lng] with the longitude' do
+    it 'sets http_request_parameters[:lng] with the longitude' do
       expect(@search_options[:lng]).to eql(4.56)
     end
 
@@ -140,7 +140,7 @@ describe Tankard::Api::Search do
         end
 
         it 'does not raise Tankard::Error::NoSearchQuery when the query is set' do
-          search.instance_variable_get(:"@options")[:q] = 'findme'
+          search.instance_variable_get(:"@http_request_parameters")[:q] = 'findme'
           expect { search.send(:raise_if_required_options_not_set) }.not_to raise_error
         end
       end
@@ -148,7 +148,7 @@ describe Tankard::Api::Search do
       context 'the endpoint is set to upc' do
 
         before do
-          search.instance_variable_get(:"@options")[:endpoint] = 'upc'
+          search.instance_variable_get(:"@http_request_parameters")[:endpoint] = 'upc'
         end
 
         it 'raises Tankard::Error::MissingParameter when code is not set' do
@@ -156,7 +156,7 @@ describe Tankard::Api::Search do
         end
 
         it 'does not raise Tankard::Error::MissingParameter when code is set' do
-          search.instance_variable_get(:"@options")[:code] = '1234'
+          search.instance_variable_get(:"@http_request_parameters")[:code] = '1234'
           expect { search.send(:raise_if_required_options_not_set) }.not_to raise_error
         end
       end
@@ -164,16 +164,16 @@ describe Tankard::Api::Search do
       context 'the endpoint is set to geo/point' do
 
         before do
-          search.instance_variable_get(:"@options")[:endpoint] = 'geo/point'
+          search.instance_variable_get(:"@http_request_parameters")[:endpoint] = 'geo/point'
         end
 
         it 'raises Tankard::Error::MissingParameter when latitude is not set' do
-          search.instance_variable_get(:"@options")[:lng] = 123
+          search.instance_variable_get(:"@http_request_parameters")[:lng] = 123
           expect { search.send(:raise_if_required_options_not_set) }.to raise_error(Tankard::Error::MissingParameter, 'missing Parameters: lat, lng')
         end
 
         it 'raises Tankard::Error::MissingParameter when longitude is not set' do
-          search.instance_variable_get(:"@options")[:lat] = 123
+          search.instance_variable_get(:"@http_request_parameters")[:lat] = 123
           expect { search.send(:raise_if_required_options_not_set) }.to raise_error(Tankard::Error::MissingParameter, 'missing Parameters: lat, lng')
         end
 
@@ -182,8 +182,8 @@ describe Tankard::Api::Search do
         end
 
         it 'does not raise Tankard::Error::MissingParameter when latitude and longitude are set' do
-          search.instance_variable_get(:"@options")[:lat] = 123
-          search.instance_variable_get(:"@options")[:lng] = 123
+          search.instance_variable_get(:"@http_request_parameters")[:lat] = 123
+          search.instance_variable_get(:"@http_request_parameters")[:lng] = 123
           expect { search.send(:raise_if_required_options_not_set) }.not_to raise_error
         end
       end
@@ -201,16 +201,16 @@ describe Tankard::Api::Search do
       context 'an endpoint is set' do
 
         before do
-          search.instance_variable_get(:"@options")[:endpoint] = 'upc'
+          search.instance_variable_get(:"@http_request_parameters")[:endpoint] = 'upc'
         end
 
         it 'adds the endpoint to the uri' do
           expect(search.send(:http_request_uri)).to eql('search/upc')
         end
 
-        it 'removes the endpoint from options' do
+        it 'removes the endpoint from http_request_parameters' do
           search.send(:http_request_uri)
-          expect(search.instance_variable_get(:"@options")[:endpoint]).to eql(nil)
+          expect(search.instance_variable_get(:"@http_request_parameters")[:endpoint]).to eql(nil)
         end
       end
     end
@@ -224,8 +224,8 @@ describe Tankard::Api::Search do
 
     describe '#http_request_parameters' do
 
-      it 'returns the options for the request' do
-        expect(search.send(:http_request_parameters).object_id).to eql(search.instance_variable_get(:"@options").object_id)
+      it 'returns the http_request_parameters for the request' do
+        expect(search.send(:http_request_parameters).object_id).to eql(search.instance_variable_get(:"@http_request_parameters").object_id)
       end
     end
   end

--- a/spec/tankard/api/style_spec.rb
+++ b/spec/tankard/api/style_spec.rb
@@ -29,7 +29,7 @@ describe Tankard::Api::Style do
 
     it 'sets the options[:id] for the style id passed in' do
       style.id(1)
-      style_options = style.instance_variable_get(:"@options")
+      style_options = style.instance_variable_get(:"@http_request_parameters")
       expect(style_options[:id]).to eql(1)
     end
 
@@ -55,6 +55,71 @@ describe Tankard::Api::Style do
 
       it 'uses the style id in the uri' do
         expect(style.id(1).map { |x| x }).to eql(['style_valid'])
+      end
+    end
+  end
+
+  describe 'private methods' do
+
+    describe '#raise_if_no_id_in_options' do
+
+      context 'when an ID is not set' do
+
+        it 'raises Tankard::Error::MissingParameter' do
+          expect { style.send(:raise_if_no_id_in_options) }.to raise_error(Tankard::Error::MissingParameter, 'No style id set')
+        end
+      end
+
+      context 'when an ID is set' do
+
+        before do
+          style.instance_variable_get(:"@http_request_parameters")[:id] = 'test'
+        end
+
+        it 'returns the id from options' do
+          expect(style.send(:raise_if_no_id_in_options)).to eql('test')
+        end
+
+        it 'removes the id from options' do
+          style.send(:raise_if_no_id_in_options)
+          expect(style.instance_variable_get(:"@http_request_parameters")[:id]).to be_nil
+        end
+      end
+    end
+
+    describe '#route' do
+
+      it 'returns the route for the api request' do
+        expect(style.send(:route)).to eql('style')
+      end
+    end
+
+    describe '#http_request_uri' do
+
+      before do
+        style.stub(:route).and_return('style')
+        style.stub(:raise_if_no_id_in_options).and_return('123')
+      end
+
+      context 'no endpoint is set' do
+
+        it 'returns the route with the id' do
+          expect(style.send(:http_request_uri)).to eql('style/123')
+        end
+      end
+    end
+
+    describe '#http_client' do
+
+      it 'returns the request variable that is passed when the class is created' do
+        expect(style.send(:http_client).object_id).to eql(@request.object_id)
+      end
+    end
+
+    describe '#http_request_parameters' do
+
+      it 'returns the options for the request' do
+        expect(style.send(:http_request_parameters).object_id).to eql(style.instance_variable_get(:"@http_request_parameters").object_id)
       end
     end
   end


### PR DESCRIPTION
in all of the current supported routes i've switched from using methods that just return a variable to using attr_reader's.  This cleans things up a bit.  I don't think it sacrifices any readability, it should make some things more obvious.

I've also gone ahead and added some more tests for style.
