### PR TITLE
fixes repeat calls to some queries

### DIFF
--- a/lib/tankard/api/beer.rb
+++ b/lib/tankard/api/beer.rb
@@ -108,16 +108,16 @@ module Tankard
       attr_reader :http_request_parameters
 
       def http_request_uri
+        @request_endpoint = "/#{@http_request_parameters.delete(:endpoint)}" if @http_request_parameters.endpoint?
         endpoint = "#{route}/#{raise_if_no_id_in_options}"
-
-        endpoint += "/#{@http_request_parameters.delete(:endpoint)}" if @http_request_parameters.endpoint?
-
+        endpoint += @request_endpoint if @request_endpoint
         endpoint
       end
 
       def raise_if_no_id_in_options
-        fail Tankard::Error::MissingParameter, 'No Beer ID is set' unless @http_request_parameters.id?
-        @http_request_parameters.delete(:id)
+        @beer_id = @http_request_parameters.delete(:id) if @http_request_parameters.id?
+        fail Tankard::Error::MissingParameter, 'No Beer ID is set' unless @beer_id
+        @beer_id
       end
 
       def route

--- a/lib/tankard/api/search.rb
+++ b/lib/tankard/api/search.rb
@@ -103,10 +103,9 @@ module Tankard
       attr_reader :http_request_parameters
 
       def http_request_uri
+        @request_endpoint = "/#{@http_request_parameters.delete(:endpoint)}" if @http_request_parameters.endpoint?
         endpoint = 'search'
-
-        endpoint += "/#{@http_request_parameters.delete(:endpoint)}" if @http_request_parameters.endpoint?
-
+        endpoint += @request_endpoint if @request_endpoint
         endpoint
       end
 

--- a/lib/tankard/api/style.rb
+++ b/lib/tankard/api/style.rb
@@ -59,8 +59,9 @@ module Tankard
       attr_reader :http_request_parameters
 
       def raise_if_no_id_in_options
-        fail Tankard::Error::MissingParameter, 'No style id set' unless @http_request_parameters.id?
-        @http_request_parameters.delete(:id)
+        @style_id = @http_request_parameters.delete(:id) if @http_request_parameters.id?
+        fail Tankard::Error::MissingParameter, 'No style id set' unless @style_id
+        @style_id
       end
 
       def route

--- a/spec/tankard/api/beer_spec.rb
+++ b/spec/tankard/api/beer_spec.rb
@@ -150,6 +150,22 @@ describe Tankard::Api::Beer do
           beer.send(:raise_if_no_id_in_options)
           expect(beer.instance_variable_get(:"@http_request_parameters")[:id]).to be_nil
         end
+
+        it 'can be called multiple times and not raise error' do
+          beer.send(:raise_if_no_id_in_options)
+          expect { beer.send(:raise_if_no_id_in_options) }.not_to raise_error
+        end
+
+        it 'caches the ID for future method calls' do
+          beer.send(:raise_if_no_id_in_options)
+          expect(beer.send(:raise_if_no_id_in_options)).to eql('test')
+        end
+
+        it 'updates the cache value if the user sets a new ID' do
+          beer.send(:raise_if_no_id_in_options)
+          beer.instance_variable_get(:"@http_request_parameters")[:id] = 'test1'
+          expect(beer.send(:raise_if_no_id_in_options)).to eql('test1')
+        end
       end
     end
 
@@ -187,6 +203,17 @@ describe Tankard::Api::Beer do
         it 'removes the endpoint from options' do
           beer.send(:http_request_uri)
           expect(beer.instance_variable_get(:"@http_request_parameters")[:endpoint]).to be_nil
+        end
+
+        it 'caches the endpoint for future method calls' do
+          beer.send(:http_request_uri)
+          expect(beer.send(:http_request_uri)).to eql('beer/123/events')
+        end
+
+        it 'updates the cached endpoint if the user sets a new one' do
+          beer.send(:http_request_uri)
+          beer.instance_variable_get(:"@http_request_parameters")[:endpoint] = 'breweries'
+          expect(beer.send(:http_request_uri)).to eql('beer/123/breweries')
         end
       end
     end

--- a/spec/tankard/api/search_spec.rb
+++ b/spec/tankard/api/search_spec.rb
@@ -212,6 +212,17 @@ describe Tankard::Api::Search do
           search.send(:http_request_uri)
           expect(search.instance_variable_get(:"@http_request_parameters")[:endpoint]).to eql(nil)
         end
+
+        it 'caches the endpoint for future method calls' do
+          search.send(:http_request_uri)
+          expect(search.send(:http_request_uri)).to eql('search/upc')
+        end
+
+        it 'updates the cached endpoint if the user sets a new one' do
+          search.send(:http_request_uri)
+          search.instance_variable_get(:"@http_request_parameters")[:endpoint] = 'geo/point'
+          expect(search.send(:http_request_uri)).to eql('search/geo/point')
+        end
       end
     end
 

--- a/spec/tankard/api/style_spec.rb
+++ b/spec/tankard/api/style_spec.rb
@@ -84,6 +84,22 @@ describe Tankard::Api::Style do
           style.send(:raise_if_no_id_in_options)
           expect(style.instance_variable_get(:"@http_request_parameters")[:id]).to be_nil
         end
+
+        it 'can be called multiple times and not raise error' do
+          style.send(:raise_if_no_id_in_options)
+          expect { style.send(:raise_if_no_id_in_options) }.not_to raise_error
+        end
+
+        it 'caches the ID for future method calls' do
+          style.send(:raise_if_no_id_in_options)
+          expect(style.send(:raise_if_no_id_in_options)).to eql('test')
+        end
+
+        it 'updates the cache value if the user sets a new ID' do
+          style.send(:raise_if_no_id_in_options)
+          style.instance_variable_get(:"@http_request_parameters")[:id] = 'test1'
+          expect(style.send(:raise_if_no_id_in_options)).to eql('test1')
+        end
       end
     end
 


### PR DESCRIPTION
fixes #3 which would happen if a user were to store the query in a variable and then call an enumerable on it multiple times.  This change caches the relevant values between method calls so they can be reused in this situation (they get removed from the http options as they do not get passed on to the API).
