### PR TITLE
clean up code duplication in various classes

### DIFF
--- a/lib/tankard/api/adjunct.rb
+++ b/lib/tankard/api/adjunct.rb
@@ -8,6 +8,22 @@ module Tankard
     # @see http://www.brewerydb.com/developers/docs-endpoint/adjunct_index
     # @author Matthew Shafer
     class Adjunct < Tankard::Api::Base::Find
+      # @!method initialize(request, options = {})
+      #   Initializes a new object
+      #
+      #   @param request [Tankard::Request]
+      #   @param options [Hash]
+      #   @return [Tankard::Api::Adjunct]
+
+      # @!method find(id_or_array, options={})
+      #   Find a single or multiple adjunct's by their id
+      #
+      #   @param id_or_array [String, Array]
+      #   @param options [Hash]
+      #   @return [Hash, Array] if a string with a adjunct id is passed to find then the hash of the adjunct's data is returned.
+      #     if an array is passed to find an array containing hashes with each adjunct's data is returned.
+      #     if an adjunct is not found nothing for that adjunct is returned.
+
     private
 
       def route

--- a/lib/tankard/api/adjunct.rb
+++ b/lib/tankard/api/adjunct.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'tankard/api/utils/find'
+require 'tankard/api/base/find'
 
 module Tankard
   module Api
@@ -7,18 +7,8 @@ module Tankard
     #
     # @see http://www.brewerydb.com/developers/docs-endpoint/adjunct_index
     # @author Matthew Shafer
-    class Adjunct
-      include Tankard::Api::Utils::Find
-
-      def initialize(request, options = {})
-        @http_client = request
-        @http_request_parameters = Hashie::Mash.new(options)
-      end
-
+    class Adjunct < Tankard::Api::Base::Find
     private
-
-      attr_reader :http_client
-      attr_reader :http_request_parameters
 
       def route
         'adjunct'

--- a/lib/tankard/api/adjuncts.rb
+++ b/lib/tankard/api/adjuncts.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'tankard/api/utils/page_finders'
+require 'tankard/api/base/page_finders'
 
 module Tankard
   module Api
@@ -7,19 +7,15 @@ module Tankard
     #
     # @see http://www.brewerydb.com/developers/docs-endpoint/adjunct_index
     # @author Matthew Shafer
-    class Adjuncts
-      include Tankard::Api::Utils::PageFinders
+    class Adjuncts < Tankard::Api::Base::PageFinders
       # @!parse include ::Enumerable
 
-      # Initialize a new object
+      # @!method initialize(request, options = {})
+      #   Initialize a new object
       #
-      # @param request [Tankard::Request]
-      # @param options [Hash]
-      # @return [Tankard::Api::Adjuncts]
-      def initialize(request, options = {})
-        @http_client = request
-        @http_request_parameters = Hashie::Mash.new(options)
-      end
+      #   @param request [Tankard::Request]
+      #   @param options [Hash]
+      #   @return [Tankard::Api::Adjuncts]
 
       # @!method each(&block)
       #   Calls the given block once for each adjunct
@@ -30,30 +26,19 @@ module Tankard
       #   @raise [Tankard::Error::HttpError] when a status other than 200 or 401 is returned
       #   @raise [Tankard::Error::LoadError] when multi json is unable to decode json
 
-      # page number to query
+      # @!method page(number)
+      #   page number to query
       #
-      # @param beer_id [String]
-      # @return [self] returns itself
-      def page(number)
-        @http_request_parameters.p = number
-        self
-      end
+      #   @param beer_id [String]
+      #   @return [self] returns itself
 
-      # Additional parameters to send with the request
+      # @!method params(options = {})
+      #   Additional parameters to send with the request
       #
-      # @param options [Hash]
-      # @return [self] returns itself
-      def params(options = {})
-        options.each_pair do |key, value|
-          @http_request_parameters[key] = value
-        end
-        self
-      end
+      #   @param options [Hash]
+      #   @return [self] returns itself
 
     private
-
-      attr_reader :http_client
-      attr_reader :http_request_parameters
 
       def http_request_uri
         'adjuncts'

--- a/lib/tankard/api/base/find.rb
+++ b/lib/tankard/api/base/find.rb
@@ -4,6 +4,9 @@ require 'tankard/api/utils/find'
 module Tankard
   module Api
     module Base
+      # Base class for routes that can find a specific type of data
+      #
+      # @author Matthew Shafer
       class Find
         include Tankard::Api::Utils::Find
 

--- a/lib/tankard/api/base/find.rb
+++ b/lib/tankard/api/base/find.rb
@@ -14,8 +14,7 @@ module Tankard
 
       private
 
-        attr_reader :http_client
-        attr_reader :http_request_parameters
+        attr_reader :http_client, :http_request_parameters
       end
     end
   end

--- a/lib/tankard/api/base/find.rb
+++ b/lib/tankard/api/base/find.rb
@@ -1,0 +1,22 @@
+require 'hashie'
+require 'tankard/api/utils/find'
+
+module Tankard
+  module Api
+    module Base
+      class Find
+        include Tankard::Api::Utils::Find
+
+        def initialize(request, options = {})
+          @http_client = request
+          @http_request_parameters = Hashie::Mash.new(options)
+        end
+
+      private
+
+        attr_reader :http_client
+        attr_reader :http_request_parameters
+      end
+    end
+  end
+end

--- a/lib/tankard/api/base/page_finders.rb
+++ b/lib/tankard/api/base/page_finders.rb
@@ -1,0 +1,36 @@
+require 'hashie'
+require 'tankard/api/utils/page_finders'
+
+module Tankard
+  module Api
+    module Base
+      # Base class for routes that can look up data across pages
+      #
+      # @author Matthew Shafer
+      class PageFinders
+        include Tankard::Api::Utils::PageFinders
+
+        def initialize(request, options = {})
+          @http_client = request
+          @http_request_parameters = Hashie::Mash.new(options)
+        end
+
+        def page(number)
+          @http_request_parameters.p = number
+          self
+        end
+
+        def params(options = {})
+          options.each_pair do |key, value|
+            @http_request_parameters[key] = value
+          end
+          self
+        end
+
+      private
+
+        attr_reader :http_client, :http_request_parameters
+      end
+    end
+  end
+end

--- a/lib/tankard/api/beer.rb
+++ b/lib/tankard/api/beer.rb
@@ -145,7 +145,6 @@ module Tankard
     private
 
       attr_reader :http_client, :http_request_parameters
-      attr_reader :http_request_parameters
 
       def http_request_uri
         @request_endpoint = "/#{@http_request_parameters.delete(:endpoint)}" if @http_request_parameters.endpoint?

--- a/lib/tankard/api/beer.rb
+++ b/lib/tankard/api/beer.rb
@@ -144,7 +144,7 @@ module Tankard
 
     private
 
-      attr_reader :http_client
+      attr_reader :http_client, :http_request_parameters
       attr_reader :http_request_parameters
 
       def http_request_uri

--- a/lib/tankard/api/beers.rb
+++ b/lib/tankard/api/beers.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'tankard/api/utils/page_finders'
+require 'tankard/api/base/page_finders'
 
 module Tankard
   module Api
@@ -7,19 +7,15 @@ module Tankard
     #
     # @see http://www.brewerydb.com/developers/docs-endpoint/beer_index
     # @author Matthew Shafer
-    class Beers
-      include Tankard::Api::Utils::PageFinders
+    class Beers < Tankard::Api::Base::PageFinders
       # @!parse include ::Enumerable
 
-      # Initializes a new object
+      # @!method initialize(request, options = {})
+      #   Initializes a new object
       #
-      # @param request [Tankard::Request]
-      # @param options [Hash]
-      # @return [Tankard::Api::Beers]
-      def initialize(request, options = {})
-        @http_client = request
-        @http_request_parameters = Hashie::Mash.new(options)
-      end
+      #   @param request [Tankard::Request]
+      #   @param options [Hash]
+      #   @return [Tankard::Api::Beers]
 
       # @!method each(&block)
       #   Calls the given block once for each beer
@@ -48,35 +44,28 @@ module Tankard
         self
       end
 
+      # Beer ibu to query with
+      #
+      # @param beer_ibu [String]
+      # @return [self] returns itself
       def ibu(beer_ibu)
         @http_request_parameters.ibu = beer_ibu
         self
       end
 
-      # Page number to request
+      # @!method page(number)
+      #   Page number to request
       #
-      # @param number [Integer]
-      # @return [self] returns itself
-      def page(number)
-        @http_request_parameters.p = number
-        self
-      end
+      #   @param number [Integer]
+      #   @return [self] returns itself
 
-      # Additional parameters to send with the request
+      # @!method params(options = {})
+      #   Additional parameters to send with the request
       #
-      # @param options [Hash]
-      # @return [self] returns itself
-      def params(options = {})
-        options.each_pair do |key, value|
-          @http_request_parameters[key] = value
-        end
-        self
-      end
+      #   @param options [Hash]
+      #   @return [self] returns itself
 
     private
-
-      attr_reader :http_client
-      attr_reader :http_request_parameters
 
       def http_request_uri
         'beers'

--- a/lib/tankard/api/category.rb
+++ b/lib/tankard/api/category.rb
@@ -1,4 +1,4 @@
-require 'tankard/api/utils/find'
+require 'tankard/api/base/find'
 
 module Tankard
   module Api
@@ -6,19 +6,13 @@ module Tankard
     #
     # @see http://www.brewerydb.com/developers/docs-endpoint/category_index
     # @author Matthew Shafer
-    class Category
-      include Tankard::Api::Utils::Find
-
-      # Initializes a new object
+    class Category < Tankard::Api::Base::Find
+      # @!method initialize(request, options = {})
+      #   Initializes a new object
       #
-      # @param request [Tankard::Request]
-      # @param options [Hash]
-      # @return [Tankard::Api::Category]
-      def initialize(request, options = {})
-        @http_client = request
-        @http_request_parameters = options
-        @route = 'category'
-      end
+      #   @param request [Tankard::Request]
+      #   @param options [Hash]
+      #   @return [Tankard::Api::Category]
 
       # @!method find(id_or_array, options={})
       #   Find a single or multiple categories by their id
@@ -31,7 +25,9 @@ module Tankard
 
     private
 
-      attr_reader :http_client, :http_request_parameters, :route
+      def route
+        'category'
+      end
     end
   end
 end

--- a/lib/tankard/api/search.rb
+++ b/lib/tankard/api/search.rb
@@ -1,4 +1,3 @@
-require 'hashie'
 require 'tankard/api/base/page_finders'
 
 module Tankard

--- a/lib/tankard/api/search.rb
+++ b/lib/tankard/api/search.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'tankard/api/utils/page_finders'
+require 'tankard/api/base/page_finders'
 
 module Tankard
   module Api
@@ -7,20 +7,15 @@ module Tankard
     #
     # @see http://www.brewerydb.com/developers/docs-endpoint/search_index
     # @author Matthew Shafer
-    class Search
-      include ::Enumerable
-      include Tankard::Api::Utils::PageFinders
+    class Search < Tankard::Api::Base::PageFinders
       # @!parse include ::Enumerable
 
-      # Initializes a new object
+      # @!method initialize(request, options = {})
+      #   Initializes a new object
       #
-      # @param request [Tankard::Request]
-      # @param options [Hash]
-      # @return [Tankard::Api::Search]
-      def initialize(request, options = {})
-        @http_client = request
-        @http_request_parameters = Hashie::Mash.new(options)
-      end
+      #   @param request [Tankard::Request]
+      #   @param options [Hash]
+      #   @return [Tankard::Api::Search]
 
       # Calls the given block once for each result
       #
@@ -44,25 +39,17 @@ module Tankard
         self
       end
 
-      # Page number to request
+      # @!method page(number)
+      #   Page number to request
       #
-      # @param number [Integer]
-      # @return [self] returns itself
-      def page(number)
-        @http_request_parameters.p = number
-        self
-      end
+      #   @param number [Integer]
+      #   @return [self] returns itself
 
-      # Additional parameters to send with the request
+      # @!method params(options = {})
+      #   Additional parameters to send with the request
       #
-      # @param options [Hash]
-      # @return [self] returns itself
-      def params(options = {})
-        options.each_pair do |key, value|
-          @http_request_parameters[key] = value
-        end
-        self
-      end
+      #   @param options [Hash]
+      #   @return [self] returns itself
 
       # Type of search to perform
       #
@@ -109,9 +96,6 @@ module Tankard
       end
 
     private
-
-      attr_reader :http_client
-      attr_reader :http_request_parameters
 
       def http_request_uri
         @request_endpoint = "/#{@http_request_parameters.delete(:endpoint)}" if @http_request_parameters.endpoint?

--- a/lib/tankard/api/style.rb
+++ b/lib/tankard/api/style.rb
@@ -1,4 +1,4 @@
-require 'tankard/api/utils/find'
+require 'tankard/api/base/find'
 
 module Tankard
   module Api
@@ -6,19 +6,13 @@ module Tankard
     #
     # @see http://www.brewerydb.com/developers/docs-endpoint/style_index
     # @author Matthew Shafer
-    class Style
-      include Tankard::Api::Utils::Find
-
-      # Initializes a new object
+    class Style < Tankard::Api::Base::Find
+      # @!method initialize(request, options = {})
+      #   Initializes a new object
       #
-      # @param request [Tankard::Request]
-      # @param options [Hash]
-      # @return [Tankard::Api::Style]
-      def initialize(request, options = {})
-        @http_client = request
-        @http_request_parameters = options
-        @route = 'style'
-      end
+      #   @param request [Tankard::Request]
+      #   @param options [Hash]
+      #   @return [Tankard::Api::Style]
 
       # @!method find(id_or_array, options={})
       #   Find a single or multiple styles by their id
@@ -28,12 +22,12 @@ module Tankard
       #   @return [Hash, Array] if a string with a style id is passed to find then the hash of the style is returned.
       #     if an array is passed to find an array containing hashes with each style is returned.
       #     if a style is not found nothing for that style is returned.
-
+      
     private
 
-      attr_reader :http_client
-      attr_reader :http_request_parameters
-      attr_reader :route
+      def route
+        'style'
+      end
     end
   end
 end

--- a/lib/tankard/api/styles.rb
+++ b/lib/tankard/api/styles.rb
@@ -1,5 +1,3 @@
-require 'hashie'
-require 'tankard/api/request/get'
 require 'tankard/api/utils/page_finders'
 
 module Tankard
@@ -9,7 +7,6 @@ module Tankard
     # @see http://www.brewerydb.com/developers/docs-endpoint/style_index
     # @author Matthew Shafer
     class Styles
-      include Tankard::Api::Request::Get
       include Tankard::Api::Utils::PageFinders
       # @!parse include ::Enumerable
 

--- a/lib/tankard/api/yeast.rb
+++ b/lib/tankard/api/yeast.rb
@@ -1,4 +1,4 @@
-require 'tankard/api/utils/find'
+require 'tankard/api/base/find'
 
 module Tankard
   module Api
@@ -6,19 +6,13 @@ module Tankard
     #
     # @see http://www.brewerydb.com/developers/docs-endpoint/yeast_index
     # @author Matthew Shafer
-    class Yeast
-      include Tankard::Api::Utils::Find
-
-      # Initializes a new object
+    class Yeast < Tankard::Api::Base::Find
+      # @!method initialize(request, options = {})
+      #   Initializes a new object
       #
-      # @param request [Tankard::Request]
-      # @param options [Hash]
-      # @return [Tankard::Api::Yeast]
-      def initialize(request, options = {})
-        @http_client = request
-        @http_request_parameters = options
-        @route = 'yeast'
-      end
+      #   @param request [Tankard::Request]
+      #   @param options [Hash]
+      #   @return [Tankard::Api::Yeast]
 
       # @!method find(id_or_array, options={})
       #   Find a single or multiple yeasts by their id
@@ -31,9 +25,9 @@ module Tankard
 
     private
 
-      attr_reader :http_client
-      attr_reader :http_request_parameters
-      attr_reader :route
+      def route
+        'yeast'
+      end
     end
   end
 end

--- a/lib/tankard/api/yeasts.rb
+++ b/lib/tankard/api/yeasts.rb
@@ -1,4 +1,3 @@
-require 'hashie'
 require 'tankard/api/base/page_finders'
 
 module Tankard

--- a/lib/tankard/api/yeasts.rb
+++ b/lib/tankard/api/yeasts.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'tankard/api/utils/page_finders'
+require 'tankard/api/base/page_finders'
 
 module Tankard
   module Api
@@ -7,20 +7,15 @@ module Tankard
     #
     # @see http://www.brewerydb.com/developers/docs-endpoint/yeast_index
     # @author Matthew Shafer
-    class Yeasts
-      include Tankard::Api::Utils::PageFinders
+    class Yeasts < Tankard::Api::Base::PageFinders
       # @!parse include ::Enumerable
 
-      # Initializes a new object
+      # @!method initialize(request, options = {})
+      #   Initializes a new object
       #
-      # @param request [Tankard::Request]
-      # @param options [Hash]
-      # @return [Tankard::Api::Yeasts]
-      def initialize(request, options = {})
-        @http_client = request
-        @http_request_parameters = Hashie::Mash.new(options)
-        @http_request_uri = 'yeasts'
-      end
+      #   @param request [Tankard::Request]
+      #   @param options [Hash]
+      #   @return [Tankard::Api::Yeasts]
 
       # @!method each(&block)
       #   Calls the given block once for each yeast
@@ -31,20 +26,23 @@ module Tankard
       #   @raise [Tankard::Error::HttpError] when a status other than 200 or 401 is returned
       #   @raise [Tankard::Error::LoadError] when multi json is unable to decode json
 
-      # Specific page to request
+      # @!method page(number)
+      #   Specific page to request
       #
-      # @param number [Integer]
-      # @return [self] returns itself
-      def page(number)
-        @http_request_parameters[:p] = number
-        self
-      end
+      #   @param number [Integer]
+      #   @return [self] returns itself
+
+      # @!method params(options = {})
+      #   Additional parameters to send with the request
+      #
+      #   @param options [Hash]
+      #   @return [self] returns itself
 
     private
 
-      attr_reader :http_client
-      attr_reader :http_request_parameters
-      attr_reader :http_request_uri
+      def http_request_uri
+        'yeasts'
+      end
 
     end
   end


### PR DESCRIPTION
A few of the api classes did practically the same thing.  I split those duplicated methods into base classes that can now be inherited from.
